### PR TITLE
fix: don't require provider input for alchemy provider

### DIFF
--- a/packages/alchemy/src/provider.ts
+++ b/packages/alchemy/src/provider.ts
@@ -50,7 +50,7 @@ export type AlchemyProviderConfig = {
      */
     preVerificationGasBufferPercent?: bigint;
   };
-} & SmartAccountProviderConfig &
+} & Omit<SmartAccountProviderConfig, "rpcProvider"> &
   ConnectionConfig;
 
 export class AlchemyProvider extends SmartAccountProvider<HttpTransport> {


### PR DESCRIPTION
don't require alchemy provider's to add rpcProvider since we generate that for them